### PR TITLE
feat: extract audio with output attributes

### DIFF
--- a/tools/extract_audio.py
+++ b/tools/extract_audio.py
@@ -1,18 +1,21 @@
+import ast
+import os
+import tempfile
+import time
 from collections.abc import Generator
 from typing import Any
-import tempfile
-import os
-import time
-import ffmpeg
 
+import ffmpeg
 from dify_plugin import Tool
 from dify_plugin.entities.tool import ToolInvokeMessage
+
 
 class ExtractAudioTool(Tool):
     def _invoke(self, tool_parameters: dict[str, Any]) -> Generator[ToolInvokeMessage, None, None]:
         video_file = tool_parameters.get('video')
         audio_format = tool_parameters.get('audio_format', 'mp3').lower()
-        
+        audio_attrs = tool_parameters.get('audio_attrs', '')
+
         # 验证输入
         if not video_file:
             yield self.create_text_message("No video file provided")
@@ -21,21 +24,21 @@ class ExtractAudioTool(Tool):
                 "message": "No video file provided"
             })
             return
-        
+
         # 验证音频格式
         valid_formats = ['mp3', 'aac', 'wav', 'ogg', 'flac']
         if audio_format not in valid_formats:
             yield self.create_text_message(f"Invalid audio format: {audio_format}. Using 'mp3' instead.")
             audio_format = 'mp3'
-        
+
         try:
             # 设置临时文件
             video_file_extension = video_file.extension if video_file.extension else '.mp4'
-            
+
             # 获取原始文件名（不带扩展名）
             orig_filename = os.path.splitext(video_file.filename)[0]
             output_filename = f"{orig_filename}.{audio_format}"
-            
+
             # 设置MIME类型映射
             mime_types = {
                 'mp3': 'audio/mpeg',
@@ -44,32 +47,38 @@ class ExtractAudioTool(Tool):
                 'ogg': 'audio/ogg',
                 'flac': 'audio/flac'
             }
-            
+
             with tempfile.NamedTemporaryFile(delete=False, suffix=video_file_extension) as in_temp_file:
                 in_temp_file.write(video_file.blob)
                 in_temp_path = in_temp_file.name
-                
+
             out_temp_path = os.path.join(tempfile.gettempdir(), f"audio_{int(time.time())}.{audio_format}")
-            
+
             try:
                 # 执行提取
                 yield self.create_text_message(f"Extracting audio from video to {audio_format} format...")
-                
+                if audio_attrs.strip():  # 有内容才解析
+                    audio_args_str = "{" + audio_attrs + "}"
+                    output_args = ast.literal_eval(audio_args_str)
+                else:
+                    output_args = {}
+                # 添加 codec（也可以写进 audio_attrs 中）
+                output_args['acodec'] = self._get_codec_for_format(audio_format)
                 # 使用ffmpeg-python库提取音频
                 (
                     ffmpeg
                     .input(in_temp_path)
-                    .output(out_temp_path, acodec=self._get_codec_for_format(audio_format))
+                    .output(out_temp_path, **output_args)
                     .run(capture_stdout=True, capture_stderr=True, overwrite_output=True)
                 )
-                
+
                 # 读取输出文件
                 with open(out_temp_path, 'rb') as out_file:
                     audio_data = out_file.read()
-                
+
                 # 计算音频文件大小
                 audio_size = os.path.getsize(out_temp_path)
-                
+
                 # 创建结果消息
                 yield self.create_blob_message(
                     audio_data,
@@ -78,7 +87,7 @@ class ExtractAudioTool(Tool):
                         "mime_type": mime_types.get(audio_format, f"audio/{audio_format}"),
                     }
                 )
-                
+
                 yield self.create_json_message({
                     "status": "success",
                     "message": f"Successfully extracted audio from video to {audio_format} format",
@@ -87,22 +96,22 @@ class ExtractAudioTool(Tool):
                     "audio_format": audio_format,
                     "audio_size": audio_size
                 })
-                
+
                 # 生成人类可读的摘要
                 summary = f"Successfully extracted audio from {video_file.filename}\n\n"
                 summary += f"Audio Format: {audio_format}\n"
                 summary += f"Output File: {output_filename}\n"
-                summary += f"Audio Size: {audio_size / (1024*1024):.2f} MB"
-                
+                summary += f"Audio Size: {audio_size / (1024 * 1024):.2f} MB"
+
                 yield self.create_text_message(summary)
-                
+
             finally:
                 # 清理临时文件
                 if os.path.exists(in_temp_path):
                     os.unlink(in_temp_path)
                 if os.path.exists(out_temp_path):
                     os.unlink(out_temp_path)
-                    
+
         except Exception as e:
             error_msg = f"Error extracting audio: {str(e)}"
             yield self.create_text_message(error_msg)
@@ -110,7 +119,7 @@ class ExtractAudioTool(Tool):
                 "status": "error",
                 "message": error_msg
             })
-    
+
     def _get_codec_for_format(self, audio_format):
         """根据音频格式返回适当的编解码器"""
         codecs = {
@@ -120,4 +129,4 @@ class ExtractAudioTool(Tool):
             'ogg': 'libvorbis',
             'flac': 'flac'
         }
-        return codecs.get(audio_format, 'copy') 
+        return codecs.get(audio_format, 'copy')

--- a/tools/extract_audio.yaml
+++ b/tools/extract_audio.yaml
@@ -38,6 +38,19 @@ parameters:
       pt_BR: O formato do áudio extraído (mp3, aac, wav, ogg, flac)
     llm_description: "The format to save the extracted audio in. Options are 'mp3', 'aac', 'wav', 'ogg', 'flac'. Default is 'mp3'."
     form: llm
+  - name: audio_attrs
+    type: string
+    required: false
+    label:
+      en_US: Audio Attrs
+      zh_Hans: 音频输出属性
+      pt_BR: Formato de Saída
+    human_description:
+      en_US: "The Attribute of the extracted audio ('ar': 16000, 'ac': 1)"
+      zh_Hans: "提取音频属性（'ar': 16000, 'ac': 1）"
+      pt_BR: "The Attribute of the extracted audio ('ar': 16000, 'ac': 1)"
+    llm_description: "The Attribute of the extracted audio. Options are ('ar': 16000, 'ac': 1). Default is empty."
+    form: llm
 extra:
   python:
     source: tools/extract_audio.py 


### PR DESCRIPTION
### What / 变更内容

This PR adds support for customizing FFmpeg audio output parameters when extracting audio from video files.

本次 PR 新增了在从视频中提取音频时自定义 FFmpeg 输出参数的能力。

---

### Why / 为什么要改

Many AI and speech models (e.g. Whisper, Wav2Vec, DeepSpeech) require audio in a specific format — typically WAV with 16000 Hz sample rate and mono channel.

许多 AI 和语音模型（如 Whisper、Wav2Vec、DeepSpeech）都要求输入音频为特定格式，通常为采样率 16000Hz 的 WAV 格式，单声道（ac=1）。

---

### Key Changes / 主要改动

**Added** 

`audio_attrs` parameter (optional), format example:  

>  'ar': 16000, 'ac': 1

 新增可选参数 `audio_attrs`，格式如下：

> 'ar': 16000, 'ac': 1

---

### Notes / 备注

- This change improves flexibility for users needing fine-grained control of audio output.
   此变更提升了插件在音频输出格式方面的灵活性，特别适用于 AI 场景。
-  Code formatting adjustments are included for consistency and readability.
   包含了部分代码格式调整，以提升一致性与可读性。 
- No breaking changes introduced.
   未引入破坏性更改。

